### PR TITLE
Remove support for logentries

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,8 @@ If no level property is specified or an unknown value is configured this will re
 
 ### logentries.com
 
-If you would like to send your logs directly to logentries instead of the default AWS console you can do so by simply setting your token in the environment:
+The previous logentries support has been causing some performance issues within AWS lambda. We have removed logentries support from this version while we take some time to further investigate. If you would like to continue using logentries with simple-lambda-logger please use v1.1.3
 
-```javascript
-process.env.LOGENTRIES_TOKEN = 'Your Token';
-//then use the logger in the same way as normal
-process.env.LOG_LEVEL = 'DEBUG';
-const logger = require('@travel-cloud/simple-lambda-logger');
-mylogger = logger.newLogger();
-mylogger.debug('Your logs');
-```
 
 ## Close
 Usage of a third party logger in AWS Lambda requires you to close the simple logger. Failure to do so will most likely result in the function timing out as chances are the third party library is keeping its connection open. Using the simple logger you simply call close before the end of your lambda function:
@@ -77,7 +69,4 @@ callback(null, response);
 Calling close returns a promise for you to await before terminating your lambda function, if the logger does not require closing a resolved promise is automatically returned.
 
 
-# Dependencies
-
-Logentries support is supplied by https://www.npmjs.com/package/le_node
 

--- a/package.json
+++ b/package.json
@@ -1,20 +1,19 @@
 {
   "name": "@travel-cloud/simple-lambda-logger",
-  "version": "1.1.3",
+  "version": "2.0.1",
   "description": "A simple logger to use with aws lambda (node version 6.10 upwards)",
   "scripts": {
     "test": "mocha test --recursive",
     "eslint-install": "(export PKG=eslint-config-airbnb; npm info \"$PKG@latest\" peerDependencies --json | command sed 's/[\\{\\},]//g ; s/: /@/g' | xargs npm install --save-dev \"$PKG@latest\")",
     "lint": "eslint . --fix"
   },
-  "dependencies": {
-    "le_node": "^1.7.0"
-  },
+  "dependencies": {},
   "main": "src/logger.js",
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.1",
+    "eslint-plugin-immutable": "^1.0.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.1.0",

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,7 +1,6 @@
-const LeLogger = require('le_node');
+
 
 const leToken = process.env.LOGENTRIES_TOKEN;
-const leLogger = leToken ? new LeLogger({ token: leToken }) : null;
 
 const levels = {
   DEBUG: 'DEBUG',
@@ -13,32 +12,13 @@ const { DEBUG, INFO, ERROR } = levels;
 
 const createTimestamp = () => new Date().toISOString();
 
-const leDebug = log => leLogger.log(`${createTimestamp()} ${DEBUG} ${log}`);
-const leInfo = log => leLogger.log(`${createTimestamp()} ${INFO} ${log}`);
-const leError = log => leLogger.log(`${createTimestamp()} ${ERROR} ${log}`);
-const leClose = () => (
-  new Promise((resolve) => {
-    leLogger.once('buffer drain', () => {
-      leLogger.closeConnection();
-      leLogger.on('disconnected', () => {
-        resolve();
-      });
-    });
-  }));
-
-
 const debug = log => console.log(`${createTimestamp()} ${DEBUG} ${log}`);
 const info = log => console.log(`${createTimestamp()} ${INFO} ${log}`);
 const error = log => console.log(`${createTimestamp()} ${ERROR} ${log}`);
 
 const logger = ({ logDebug = false, logInfo = false, logError = false }) => {
-  if (leLogger) {
-    return {
-      debug: logDebug ? leDebug : () => {},
-      info: logInfo ? leInfo : () => {},
-      error: logError ? leError : () => {},
-      close: leClose,
-    };
+  if (leToken) {
+    console.log(`${createTimestamp()} ${ERROR} Logentires disabled in current version please use 1.1.3`);
   }
   return {
     debug: logDebug ? debug : () => {},
@@ -65,6 +45,7 @@ const newLogger = (level = process.env.LOG_LEVEL || ERROR) => {
   }
 };
 
+//eslint-disable-next-line
 module.exports = {
   newLogger,
   levels,


### PR DESCRIPTION
We have taken the decision to temporarily remove logentires support while investigation into some reported performance issues. If you would like to continue using logentries with simple-lambda-logger please use v1.1.3

Signed-off-by: Robin <robin.smith@clicktravel.com>